### PR TITLE
chore: add structlog logger to example function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pyarrow>=16.1.0
-
 # use the wheel included in the repo until the package is
 # officially released and published to PyPi
 ./libs/gooddata_flight_server-1.21.0-py3-none-any.whl
+
+pyarrow>=16.1.0
+structlog

--- a/src/flexfun/sample_function.py
+++ b/src/flexfun/sample_function.py
@@ -3,8 +3,11 @@ from typing import Optional
 
 import gooddata_flight_server as gf
 import pyarrow
+import structlog
 from gooddata_flight_server import ServerContext
 from gooddata_flight_server.tasks.base import ArrowData
+
+_LOGGER = structlog.get_logger("sample_flex_function")
 
 
 class SampleFlexFunction(gf.FlexFun):
@@ -64,6 +67,8 @@ class SampleFlexFunction(gf.FlexFun):
         columns: Optional[tuple[str, ...]],
         headers: dict[str, list[str]],
     ) -> ArrowData:
+        _LOGGER.info("function_called", parameters=parameters)
+
         return self._StaticData
 
     @staticmethod

--- a/tests/flexfun/try_dev_server.py
+++ b/tests/flexfun/try_dev_server.py
@@ -12,5 +12,18 @@ def _list_flexfuns():
         print(f"Function result:\n{flight_info.schema}")
 
 
+def _call_sample_function():
+    c = pyarrow.flight.FlightClient("grpc://127.0.0.1:17001")
+    flight_info = c.get_flight_info(
+        pyarrow.flight.FlightDescriptor.for_command(
+            orjson.dumps({"function_name": "SampleFlexFunction"})
+        )
+    )
+    data = c.do_get(flight_info.endpoints[0].ticket).read_all()
+
+    print(data)
+
+
 if __name__ == "__main__":
     _list_flexfuns()
+    _call_sample_function()


### PR DESCRIPTION
- add structlog as explicit dependency; unpinned -> the underlying server lib already uses structlog so keep its version
- added example of function call to tests

JIRA: CQ-555