### PR TITLE
fix: enable the modern execution flow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       APP_LOGLEVEL: "INFO"
       GDCN_LICENSE_KEY: ${GDCN_LICENSE_KEY}
       GDC_FEATURES_VALUES_ENABLE_FLIGHTRPC_DATA_SOURCE: "true"
+      GDC_FEATURES_VALUES_ENABLE_MODERN_EXECUTION_FLOW: "true"
 #
 # extra tuning for some of the services running inside the AIO.
 #


### PR DESCRIPTION
Without the modern execution flow, the execution context will not be sent properly.

JIRA: CQ-577
risk: low