### PR TITLE
fix: add methods provider to docker-based init

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
       - ./config:/tmp/config:Z
     command:
       - start
+      - --methods-provider
+      - gooddata_flexfun
       - --config
       - /tmp/config/dev.server.toml
       - /tmp/config/flexfun.config.toml

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -83,6 +83,7 @@ docker run \
   -p ${GOODDATA_FLIGHT_SERVER__ADVERTISE_PORT}:${GOODDATA_FLIGHT_SERVER__ADVERTISE_PORT} \
   --volume $CERTS_DIR:/tls-files:Z \
   flexfun-server:latest start \
+  --methods-provider gooddata_flexfun \
   --config \
     /config/${CONFIG_ENV}.server.toml \
     /config/flexfun.config.toml \


### PR DESCRIPTION
When introducing the methods-provider argument, I forgot to add it to the docker-related scripts as well.

JIRA: CQ-755
risk: low